### PR TITLE
Fix: walletconnect security vulnerable

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "sass": "^1.35.1",
     "tailwindcss": "^2.1.4",
     "typescript": "4.3.5"
+  },
+  "resolutions": {
+    "**/@walletconnect/socket-transport/ws": "7.4.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5774,12 +5774,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
-  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
-
-ws@7.4.6:
+ws@7.3.0, ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==


### PR DESCRIPTION
This is a temporary fix before `@web3-react/walletconnect-connector` will upgrade the deps version.